### PR TITLE
Bugfix to maj min patch raise invalid version

### DIFF
--- a/pysemver/semantic.py
+++ b/pysemver/semantic.py
@@ -43,6 +43,8 @@ class Version(object):
         @returns (major, minor, version) integer tuple
         @raises InvalidVersion if the version string is not parsable
         '''
+        if version.count('.') > 2:
+            raise InvalidVersion('version is invalid')
         mmp_finder = re.compile('(\d+)\.?(\d+)?\.?(\d+)?')
         matcher = mmp_finder.search(version)
         if matcher is None:

--- a/pysemver/semantic.py
+++ b/pysemver/semantic.py
@@ -44,7 +44,9 @@ class Version(object):
         @raises InvalidVersion if the version string is not parsable
         '''
         if version.count('.') > 2:
-            raise InvalidVersion('version is invalid')
+            raise InvalidVersion(
+                'Invalid version {0} cannot contain more than 2 dots'.format(version)
+            )
         mmp_finder = re.compile('(\d+)\.?(\d+)?\.?(\d+)?')
         matcher = mmp_finder.search(version)
         if matcher is None:

--- a/pysemver/tests/unit/TestVersion.py
+++ b/pysemver/tests/unit/TestVersion.py
@@ -175,7 +175,15 @@ class TestVersion():
         inst = semantic.Version('4.5.6')
 
         # This is where we expect our invalid version to be raised
-        inst.to_maj_min_patch(invalid_version)
+        try:
+            inst.to_maj_min_patch(invalid_version)
+        except semantic.InvalidVersion as e:
+            expected_err_msgs = [
+                'Invalid version {0} must be numeric'.format(invalid_version),
+                'Invalid version {0} cannot contain more than 2 dots'.format(invalid_version)
+            ]
+            nt.assert_in(str(e), expected_err_msgs)
+            raise
 
 
 


### PR DESCRIPTION
Bug fix for semantic.py in method to_maj_min_patch to raise InvalidVersion when version like '2.3.4.2' is passed as version argument.
